### PR TITLE
Add SMS fallback and phone number normalization

### DIFF
--- a/PULL_REQUEST.md
+++ b/PULL_REQUEST.md
@@ -1,0 +1,47 @@
+# Enhancement: Add SMS Fallback and Phone Number Normalization
+
+## Problem
+The current iMessage MCP server has two significant issues:
+1. **Silent failures**: When recipients don't support iMessage (Android users), messages fail silently without any fallback
+2. **Phone number format incompatibility**: US SMS carriers often reject messages with +1 country codes
+
+## Solution
+This PR adds two key enhancements:
+
+### 1. Automatic SMS Fallback
+- **Tries iMessage first** for enhanced features when available
+- **Automatically falls back to SMS** when iMessage fails
+- **Clear reporting** of which service was actually used
+- **Better error handling** with specific failure messages
+
+### 2. Phone Number Normalization
+- **Automatically removes +1 country codes** for SMS compatibility
+- **Prevents carrier rejection errors** for US phone numbers
+- **Maintains original format for iMessage** (which is more flexible)
+
+## Changes Made
+- Added `normalizePhoneNumber()` function for SMS compatibility
+- Added `sendMessageWithFallback()` function with intelligent service selection
+- Updated `send_imessage` tool to use the enhanced fallback logic
+- Enhanced error reporting to show which service succeeded/failed
+- Updated tool description to reflect SMS fallback capability
+
+## Benefits
+- ✅ **Universal compatibility** with both iPhone and Android recipients
+- ✅ **Reliable delivery** through automatic SMS fallback
+- ✅ **Better user experience** with clear service reporting
+- ✅ **Phone number format tolerance** (handles +1 prefixes automatically)
+- ✅ **Backward compatible** - same API, enhanced functionality
+
+## Testing
+Tested with:
+- iPhone users (iMessage preferred)
+- Android users (SMS fallback)
+- Various phone number formats (+1, without country code)
+- Error scenarios (invalid numbers, service unavailable)
+
+## Example Output
+Before: `Message sent successfully to +12147702200`
+After: `Message sent successfully to +12147702200 via SMS`
+
+This gives users clear feedback about how their message was delivered.

--- a/src/index.ts
+++ b/src/index.ts
@@ -35,6 +35,66 @@ async function runAppleScript(script: string): Promise<string> {
   }
 }
 
+// Function to normalize phone number for SMS compatibility
+function normalizePhoneNumber(recipient: string): string {
+  // Remove +1 country code for SMS compatibility with US carriers
+  if (recipient.startsWith("+1")) {
+    return recipient.substring(2);
+  }
+  return recipient;
+}
+
+// Enhanced send message function with SMS fallback
+async function sendMessageWithFallback(recipient: string, message: string): Promise<{success: boolean, serviceUsed: string, error?: string}> {
+  const escapedMessage = message.replace(/"/g, '\\"');
+  const escapedRecipient = recipient.replace(/"/g, '\\"');
+  
+  // Try iMessage first
+  try {
+    const imessageScript = `
+      tell application "Messages"
+        try
+          send "${escapedMessage}" to buddy "${escapedRecipient}" of (service 1 whose service type = iMessage)
+          return "SUCCESS"
+        on error
+          return "FAILED"
+        end try
+      end tell
+    `;
+    
+    const result = await runAppleScript(imessageScript);
+    if (result === "SUCCESS") {
+      return {success: true, serviceUsed: "iMessage"};
+    }
+  } catch (error) {
+    // Continue to SMS fallback
+  }
+  
+  // Fall back to SMS
+  try {
+    const normalizedRecipient = normalizePhoneNumber(escapedRecipient);
+    const smsScript = `
+      tell application "Messages"
+        try
+          send "${escapedMessage}" to buddy "${normalizedRecipient}" of (service 1 whose service type = SMS)
+          return "SUCCESS"
+        on error errorMessage
+          return "FAILED: " & errorMessage
+        end try
+      end tell
+    `;
+    
+    const result = await runAppleScript(smsScript);
+    if (result === "SUCCESS") {
+      return {success: true, serviceUsed: "SMS"};
+    } else {
+      return {success: false, serviceUsed: "SMS", error: result};
+    }
+  } catch (error) {
+    return {success: false, serviceUsed: "SMS", error: getErrorMessage(error)};
+  }
+}
+
 const server = new Server(
   {
     name: "iMessage-AppleScript-Server",
@@ -122,7 +182,7 @@ server.setRequestHandler(ListToolsRequestSchema, async () => {
     tools: [
       {
         name: "send_imessage",
-        description: "Send an iMessage using Messages app",
+        description: "Send a message using Messages app (tries iMessage first, falls back to SMS)",
         inputSchema: {
           type: "object",
           properties: {
@@ -166,23 +226,29 @@ server.setRequestHandler(CallToolRequestSchema, async (request) => {
         throw new Error("Recipient and message are required");
       }
 
-      const escapedMessage = message.replace(/"/g, '\\"');
-      const script = `
-        tell application "Messages"
-          send "${escapedMessage}" to buddy "${recipient}" of (service 1 whose service type = iMessage)
-        end tell
-      `;
-
       try {
-        await runAppleScript(script);
-        return {
-          content: [
-            {
-              type: "text",
-              text: `Message sent successfully to ${recipient}`,
-            },
-          ],
-        };
+        const result = await sendMessageWithFallback(recipient, message);
+        
+        if (result.success) {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Message sent successfully to ${recipient} via ${result.serviceUsed}`,
+              },
+            ],
+          };
+        } else {
+          return {
+            content: [
+              {
+                type: "text",
+                text: `Failed to send message to ${recipient}: ${result.error || 'Unknown error'}`,
+              },
+            ],
+            isError: true,
+          };
+        }
       } catch (error) {
         return {
           content: [


### PR DESCRIPTION
- Add automatic SMS fallback when iMessage fails
- Normalize phone numbers for SMS compatibility (remove +1 prefix)
- Enhanced error reporting with service type indication
- Maintain backward compatibility while improving reliability
- Fixes silent failures with Android users and SMS carrier rejections